### PR TITLE
Gemfile.lockにherokuのプラットフォームを追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.8-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.8-x86_64-linux)
+      racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.2.1)
       ast (~> 2.4.1)
@@ -245,6 +247,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bcrypt (= 3.1.12)


### PR DESCRIPTION
Herokuのビルドログに従った

```
-----> Ruby app detected
-----> Installing bundler 2.3.10
-----> Removing BUNDLED WITH version in the Gemfile.lock
-----> Compiling Ruby/Rails
###### WARNING:
       Your app was upgraded to bundler 2.3.10.
       Previously you had a successful deploy with bundler 2.2.21.
       
       If you see problems related to the bundler version please refer to:
       https://devcenter.heroku.com/articles/bundler-version#known-upgrade-issues
       
-----> Using Ruby version: ruby-3.1.2
       Ruby version change detected. Clearing bundler cache.
       Old: ruby 2.7.4p191 (2021-07-07 revision a21a3b7d23) [x86_64-linux]
       New: ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux]
-----> Installing dependencies using bundler 2.3.10
       Running: BUNDLE_WITHOUT='development:test' BUNDLE_PATH=vendor/bundle BUNDLE_BIN=vendor/bundle/bin BUNDLE_DEPLOYMENT=1 bundle install -j4
       Your bundle only supports platforms ["arm64-darwin-21"] but your local platform
       is x86_64-linux. Add the current platform to the lockfile with
       `bundle lock --add-platform x86_64-linux` and try again.
       Bundler Output: Your bundle only supports platforms ["arm64-darwin-21"] but your local platform
       is x86_64-linux. Add the current platform to the lockfile with
       `bundle lock --add-platform x86_64-linux` and try again.
 !
 !     Failed to install gems via Bundler.
 !
 !     Push rejected, failed to compile Ruby app.
 !     Push failed

```